### PR TITLE
Feature/error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,26 +78,17 @@ app.get('/all-batch-info', batches.getBatchInfo);
 
 app.get('/test-add', importer.add_batch);
 
-app.get('/test-img', images.getBatchStatus);
+app.get('/batch-status', images.getBatchStatus);
 
 app.get('/sample_script.js', function(req, res) {
 	res.sendFile(dir + 'sample_script.js');
-});
-
-app.get('/confirm', function(req, res) {
-    res.send("Confirmed request");
-	//res.send(req.url);
-});
-
-app.get('/deny', function(req, res) {
-	res.send("Denied request");
 });
 
 app.get('/add-directory', function(req, res) {
     res.sendFile(dir + 'pages/add_directory.html');
 });
 
-app.post('/insert_name', function(req, res) {
+app.post('/insert-name', function(req, res) {
     let name = [req.body.name];
     db.none("INSERT INTO users (username) VALUES ($1)", name)
         .then( () => {

--- a/app.js
+++ b/app.js
@@ -105,13 +105,13 @@ app.post('/annotate', function(req, res) {
 	let data = ['imageid', 'user', 'annotation', 'feature'].map(attr => req.body[attr]);
 	// if any are not included
 	if (data.some(a => a === undefined)) {
-		res.status(404).send({client: "Error: Invalid data format"});
+		res.status(400).send({client: "Error: Invalid data format"});
 		return;
 	}
 	db.none("INSERT INTO annotation(imageid, username, annotation, feature) VALUES($1, $2, $3, $4)", data)
 	.then(() => res.send("Annotation added"))
 	.catch(err => {
-		res.status(404).send({client: "Error: Annotation failed", server: err});
+		res.status(400).send({client: "Error: Annotation failed", server: err});
 		console.log(err);
 	});
 });

--- a/app.js
+++ b/app.js
@@ -56,7 +56,9 @@ app.get('/feature-list', function(req, res) {
 });
 
 app.get('/annotation', function(req, res) {
-	let imgID = req.query.index;
+	res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+	res.setHeader("Pragma", "no-cache");
+	res.setHeader("Expires", "0");
 	res.sendFile(dir + 'pages/annotation.html');
 });
 

--- a/app.js
+++ b/app.js
@@ -112,13 +112,13 @@ app.post('/annotate', function(req, res) {
 	let data = ['imageid', 'user', 'annotation', 'feature'].map(attr => req.body[attr]);
 	// if any are not included
 	if (data.some(a => a === undefined)) {
-		res.status(400).send("Error: Invalid data format");
+		res.status(404).send({client: "Error: Invalid data format"});
 		return;
 	}
 	db.none("INSERT INTO annotation(imageid, username, annotation, feature) VALUES($1, $2, $3, $4)", data)
 	.then(() => res.send("Annotation added"))
 	.catch(err => {
-		res.status(500).send("Error: Annotation failed");
+		res.status(404).send({client: "Error: Annotation failed", server: err});
 		console.log(err);
 	});
 });

--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ app.get('/complete', function(req, res) {
     res.sendFile(dir + 'pages/export.html');
 });
 
-app.get('/images', images.get_img);
+app.get('/images', images.getImage);
 
 app.get('/export', exporter.export_csv);
 
@@ -78,7 +78,7 @@ app.get('/all-batch-info', batches.getBatchInfo);
 
 app.get('/test-add', importer.add_batch);
 
-app.get('/test-img', images.get_batch_status);
+app.get('/test-img', images.getBatchStatus);
 
 app.get('/sample_script.js', function(req, res) {
 	res.sendFile(dir + 'sample_script.js');

--- a/pages/add_directory.html
+++ b/pages/add_directory.html
@@ -13,6 +13,7 @@
         crossorigin="anonymous"></script>
         <script src="../scripts/awesomplete/awesomplete.js"></script>
         <script src="../scripts/add_directory.js"></script>
+        <script src="../scripts/errors.js"></script>
         <link rel="stylesheet" href="../scripts/awesomplete/awesomplete.css">
         <link rel="stylesheet" href="../styles/add_directory.css">
         <meta charset="UTF-8">

--- a/pages/annotation.html
+++ b/pages/annotation.html
@@ -4,12 +4,14 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js"></script>
         <script src="../scripts/annotation.js"></script>
+        <script src="../scripts/errors.js"></script>
         <script src="../scripts/jquery.hammer.js"></script>
         <script src="../scripts/openseadragon.min.js"></script>
         <!-- Bootstrap -->
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
         <link href="https://fonts.googleapis.com/css?family=Open+Sans|Sansita" rel="stylesheet">
+
         <link rel="stylesheet" href="../styles/theme.css">
         <link rel="stylesheet" href="../styles/annotation.css">
     </head>

--- a/pages/annotation.html
+++ b/pages/annotation.html
@@ -14,6 +14,11 @@
 
         <link rel="stylesheet" href="../styles/theme.css">
         <link rel="stylesheet" href="../styles/annotation.css">
+
+        <!--Cache settings-->
+        <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate" />
+        <meta http-equiv="pragma" content="no-cache" />
+        <meta http-equiv="expires" content="0" />
     </head>
     <body>
         <div id="navbar" class="row">

--- a/pages/home.html
+++ b/pages/home.html
@@ -25,6 +25,7 @@
     <!-- Local JavaScript-->
     <script src="../scripts/batch_list.js"></script>
     <script src="../scripts/home.js"></script>
+    <script src="../scripts/errors.js"></script>
 
 </head>
 <body>

--- a/scripts/add_directory.js
+++ b/scripts/add_directory.js
@@ -175,7 +175,8 @@ function submitBatch(n) {
                 buttons.each(function(i, b) { b.onclick = undefined;});
                 break;
             case "FAIL":
-                resAlert += `alert-danger'><strong>Failed: </strong>${res.err_msg}</div>`;
+                resAlert += `alert-danger'><strong>Failed: </strong>${res.err_msg.client}</div>`;
+                console.log(res.img_errs.server);
                 $(buttons[0]).text("Retry");
                 buttons.toggleClass("disabled");
                 break;

--- a/scripts/add_directory.js
+++ b/scripts/add_directory.js
@@ -34,7 +34,8 @@ $(function() {
         $(input).focus(function(ev) {
             autocomplete.evaluate();
         });
-    });
+    })
+        .fail(err => { showModalServerError(err) });
 
     $("#add-directory-form").submit(function(ev) {
         ev.preventDefault();
@@ -181,14 +182,15 @@ function submitBatch(n) {
                 buttons.toggleClass("disabled");
                 break;
             default:
-                console.log("Unexpected response");
+                showModalClientError("Unexpected response from server: " + res.result);
                 break;
         }
         $("#alert-wrapper-" + n).html($(resAlert));
         // activate tooltips
         $("#alert-wrapper-" + n + ' [data-toggle="tooltip"]').tooltip();
         $(".glyphicon", buttons).toggleClass("hidden");
-    });
+    })
+        .fail(err => { showModalServerError(err) });
 }
 
 function makeImgErrorHover(img, err) {
@@ -212,82 +214,3 @@ function addSubfolders() {
     let successes = res.filter(b => b).length;
     resultTextMult(successes, res.length - successes);
 }
-
-/*// iterator used to give unique id to each folder in makeFolder
-let f_i = 0
-
-// list of folders that have been selected by the user
-// updated during runtime
-let selectedFolders = [];
-
-function makeFolder(folderObj) {
-    let parent = document.createElement('ul');
-    parent.classList.add('list-group');
-    for (let f in folderObj) {
-        if (f == "files") {
-            for (let fileName of folderObj.files) {
-                let file = document.createElement('li');
-                file.classList = "list-group-item file";
-                file.innerText = fileName;
-                parent.appendChild(file);
-            }
-        }
-        else {
-            let folder = $('<li class="folder list-group-item" id="folder-' + f_i + '">' +
-            '<a class="folder-link collapsed" role="button" href="#folder-' + 
-            f_i + '-content" data-toggle="collapse" aria-expanded="false"><span class="caret"></span>' + 
-            f + '</a><div class="folder-list collapse" id="folder-' + f_i++ + '-content"></div></li>');
-            // Refer to add_directory.js for more information on recursion
-            $('div', folder).append(makeFolder(folderObj[f]));
-            $(parent).append(folder);
-        }
-    }
-    return parent;
-}
-
-$(function() {
-    $.getJSON('scripts/folder.json').done(function(folderObj) {
-        $("#dir-list-wrapper").append(makeFolder(folderObj));
-        $('.folder').click(function(ev) {
-            // dont do anything if a child of the folder was clicked on
-            if (ev.target !== this) {
-                return;
-            }
-            // inner text will usually grab the children text too,
-            // this just grabs the parent text
-            let tarText = ev.target.innerText.split("\n")[0];
-            if ($(ev.target).hasClass('selected')) {
-                // find it in the selected list, remove it
-                for (let f in selectedFolders) {
-                    if (selectedFolders[f][0] == tarText) {
-                        $(".selected-pill:eq(" + f + ")").remove();
-                        selectedFolders.splice(f, 1);
-                        break;
-                    }
-                }
-                $(ev.currentTarget).removeClass('selected');
-            }
-            else {
-                let c = $('<span class="selected-pill"><span pos="' + selectedFolders.length 
-                + '" class="selected-pill-close glyphicon glyphicon-remove"></span>' + 
-                tarText + '</span>');
-                $(".selected-pill-close", c).click(function(ev) {
-                    // callback that deletes the selections when you click on the x
-                    for (let n in selectedFolders) {
-                        if (selectedFolders[n][0] == $(this).parent().text()) {
-                            $("#" + selectedFolders[n][1]).removeClass('selected');
-                            selectedFolders.splice(n, 1);
-                            $("#selected-list .selected-pill:eq(" + n + ")").remove();
-                        }
-                    }
-                });
-                $("#selected-list").append(c);
-                selectedFolders.push([tarText, ev.target.id])
-                $(ev.currentTarget).addClass('selected');
-            }
-            // don't let it propagate to the parent elements
-            ev.stopPropagation();
-        });
-    });
-});
-*/

--- a/scripts/annotation.js
+++ b/scripts/annotation.js
@@ -8,7 +8,7 @@ $.urlParam = function (a) {
     if (b == null) {
         return null;
     } else {
-        return b[1] || 0;
+        return decodeURI(b[1]) || 0;
     }
 };
 
@@ -35,7 +35,7 @@ $(document).ready( ()=> {
         getNextImage();
     })
     .fail((err) => {
-        showModalError(err);
+        showModalServerError(err, true);
     });
 
     document.onkeyup = function (event) {
@@ -106,11 +106,11 @@ $(document).ready( ()=> {
                     getNextImage()
                 })
                 .fail(err => {
-                    showModalError(err);
+                    showModalServerError(err, true);
                 })
         }
         else {
-            window.location.href = 'complete'
+            window.location.href = '/complete'
         }
     }
 
@@ -127,7 +127,7 @@ $(document).ready( ()=> {
         });
         if (image === undefined) {
             // batch done, do something here
-            window.location.href = 'complete'
+            window.location.href = '/complete'
         }
         else {
             image = image.id;
@@ -140,13 +140,13 @@ $(document).ready( ()=> {
             let imgURL = '/images?id=' + image;
             image_div
                 .on("error", (err) => {
-                    // TODO: make a modal dialog for this, and move to the next image or return home
+                    // if the image failed to retrieve, find out why
                     $.get(imgURL)
                         .done(() => {
                             // this should never happen, but if it does we'll just try again
                             image_div.attr('src', imgURL);
                         })
-                        .fail(err => { showModalError(err) });
+                        .fail(err => { showModalServerError(err) });
                 })
                 .attr('src', imgURL);
         }

--- a/scripts/batch_list.js
+++ b/scripts/batch_list.js
@@ -24,6 +24,8 @@ function createBatchUI(container_id) {
             batch_list += makeYear(y, batch_dict[y]);
         }
         $("#" + container_id).html(batch_list + "</ul>");
+    }).fail(err => {
+        showModalError(err);
     });
 }
 

--- a/scripts/batch_list.js
+++ b/scripts/batch_list.js
@@ -25,7 +25,7 @@ function createBatchUI(container_id) {
         }
         $("#" + container_id).html(batch_list + "</ul>");
     }).fail(err => {
-        showModalError(err);
+        showModalServerError(err);
     });
 }
 

--- a/scripts/errors.js
+++ b/scripts/errors.js
@@ -8,9 +8,21 @@ let modalDivContent = `
         <div class="modal-content">
             <div class="alert alert-danger modal-header" style="margin-bottom: 0;">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h3 class="modal-title alert-danger" id="myModalLabel">Something went wrong...</h3>
+                <h3 class="modal-title alert-danger">Something went wrong...</h3>
             </div>
-            <div class="modal-body text-center">
+            <div id="err-body" class="modal-body text-center lead">
+            </div>
+            <div id="err-panel" class="panel panel-warning" style="margin-bottom: 0;">
+                <div class="panel-heading">
+                    <h5 class="panel-title">
+                        <a data-toggle="collapse" href="#err-panel-content">Server Output</a>
+                    </h5>
+                </div>
+                <div id="err-panel-content" class="panel-collapse collapse">
+                    <div class="panel-body">
+                        <pre id="err-pre-text">Panel body</pre>
+                    </div>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
@@ -29,11 +41,13 @@ let showModalError;
 //      - change its text to the error message
 //      - display the modal
 // Outpus: None
-showModalError = function(err) {
+showModalError = function(err_msg, server_output) {
     // let response = err.responseText;
     if ($('#err-modal').length === 0) {
         $('body').append(modalDivContent);
     }
-    $('#err-modal .modal-body').text(err);
+    $('#err-body').text(err_msg);
+    if (server_output) { $("#err-pre-text").text(server_output)}
+    else { $("#err-panel").hide()}
     $('#err-modal').modal('show');
 };

--- a/scripts/errors.js
+++ b/scripts/errors.js
@@ -41,14 +41,33 @@ let showModalError;
 //      - change its text to the error message
 //      - display the modal
 // Outpus: None
-showModalError = function(err_msg, server_output) {
-    // let response = err.responseText;
+showModalError = function(err) {
     if ($('#err-modal').length === 0) {
         $('body').append(modalDivContent);
     }
-    $('#err-body').text(err_msg);
-    console.log(server_output)
-    if (server_output) { $("#err-pre-text").text(JSON.stringify(server_output).replace(/,/g, ",\n"))}
-    else { $("#err-panel").hide()}
-    $('#err-modal').modal('show');
+    try {
+        let response = JSON.parse(err.responseText);
+        let errMsg = response.client;
+        let serverOutput = response.server;
+        if (!errMsg && !serverOutput) {
+            $('#err-body').text("Unexpected error response from server");
+            $("#err-pre-text").text(JSON.stringify(err).replace(/,/g, ",\n"))
+        }
+        else {
+            $('#err-body').text(errMsg);
+            if (serverOutput) {
+                $("#err-pre-text").text(JSON.stringify(serverOutput).replace(/,/g, ",\n"))
+            }
+            else {
+                $("#err-panel").hide()
+            }
+        }
+    }
+    catch (exception) {
+        $('#err-body').text("Unexpected error response from server");
+        $("#err-pre-text").text(JSON.stringify(err).replace(/,/g, ",\n"))
+    }
+    finally {
+        $('#err-modal').modal('show');
+    }
 };

--- a/scripts/errors.js
+++ b/scripts/errors.js
@@ -47,7 +47,8 @@ showModalError = function(err_msg, server_output) {
         $('body').append(modalDivContent);
     }
     $('#err-body').text(err_msg);
-    if (server_output) { $("#err-pre-text").text(server_output)}
+    console.log(server_output)
+    if (server_output) { $("#err-pre-text").text(JSON.stringify(server_output).replace(/,/g, ",\n"))}
     else { $("#err-panel").hide()}
     $('#err-modal').modal('show');
 };

--- a/scripts/errors.js
+++ b/scripts/errors.js
@@ -1,0 +1,39 @@
+/**
+ * Created by Matthew Bowden on 5/4/17.
+ */
+
+let modalDivContent = `
+<div class="modal fade" id="err-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="alert alert-danger modal-header" style="margin-bottom: 0;">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h3 class="modal-title alert-danger" id="myModalLabel">Something went wrong...</h3>
+            </div>
+            <div class="modal-body text-center">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+let showModalError;
+
+// Author: Matthew
+// Purpose: Create a common modal dialog that will display errors from the server
+// Actions:
+//      - add a modal component to the DOM
+//      - change its text to the error message
+//      - display the modal
+// Outpus: None
+showModalError = function(err) {
+    // let response = err.responseText;
+    if ($('#err-modal').length === 0) {
+        $('body').append(modalDivContent);
+    }
+    $('#err-modal .modal-body').text(err);
+    $('#err-modal').modal('show');
+};

--- a/scripts/errors.js
+++ b/scripts/errors.js
@@ -1,9 +1,17 @@
 /**
  * Created by Matthew Bowden on 5/4/17.
  */
+$.urlParam = function (a) {
+    let b = new RegExp("[?&]" + a + "=([^&#]*)").exec(window.location.href);
+    if (b == null) {
+        return null;
+    } else {
+        return decodeURI(b[1]) || 0;
+    }
+};
 
-let modalDivContent = `
-<div class="modal fade" id="err-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+let modalDivServerContent = `
+<div class="modal fade" id="err-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="alert alert-danger modal-header" style="margin-bottom: 0;">
@@ -25,14 +33,14 @@ let modalDivContent = `
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
+                <button id="err-dismiss" type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
             </div>
         </div>
     </div>
 </div>
 `;
 
-let showModalError;
+let showModalServerError;
 
 // Author: Matthew
 // Purpose: Create a common modal dialog that will display errors from the server
@@ -40,10 +48,20 @@ let showModalError;
 //      - add a modal component to the DOM
 //      - change its text to the error message
 //      - display the modal
+// Inputs: jqXHR response error, redirect to homepage flag
 // Outpus: None
-showModalError = function(err) {
+showModalServerError = function(err, redirect) {
     if ($('#err-modal').length === 0) {
-        $('body').append(modalDivContent);
+        $('body').append(modalDivServerContent);
+    }
+    if (redirect) {
+
+        let homeAnchor = '/home';
+        let name = $.urlParam('name');
+        if (name) { homeAnchor += `?name=${name}`}
+        $('#err-modal').on('hidden.bs.modal', function() {
+            window.location.href = homeAnchor;
+        })
     }
     try {
         let response = JSON.parse(err.responseText);
@@ -70,4 +88,45 @@ showModalError = function(err) {
     finally {
         $('#err-modal').modal('show');
     }
+};
+
+let modalDivClientContent = `
+<div class="modal fade" id="warn-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="alert alert-warning modal-header" style="margin-bottom: 0;">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h3 class="modal-title alert-warning">Something went wrong...</h3>
+            </div>
+            <div id="warn-body" class="modal-body text-center lead">
+            </div>
+            <div class="modal-footer">
+                <button id="warn-dismiss" type="button" class="btn btn-warning" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+let showModalClientError;
+
+// Author: Matthew
+// Purpose: Create a common modal dialog that will display errors from the client side in the form of warnings
+// Actions:
+//      - add a modal component to the DOM
+//      - change its text to the error message
+//      - display the modal
+// Inputs: error message string
+// Outpus: None
+showModalClientError = function(errMsg) {
+    if ($('#warn-modal').length === 0) {
+        $('body').append(modalDivClientContent);
+    }
+    if (!errMsg) {
+        $('#warn-body').text("Unexpected error on page");
+    }
+    else {
+        $('#warn-body').text(errMsg);
+    }
+    $('#warn-modal').modal('show');
 };

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -82,7 +82,8 @@ $(document).ready( ()=> {
                 $("#" + listCounter).click({ftr: feature}, changeDropdownText);
             }
         }
-    });
+    })
+    .fail(err => { showModalError(err) });
 
     $(`#new-batch`).click(postToAnnotation);
     $(`#continue-batch`).click(postToAnnotation);

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -3,7 +3,7 @@ $.urlParam = function (a) {
     if (b == null) {
         return null;
     } else {
-        return b[1] || 0;
+        return decodeURI(b[1]) || 0;
     }
 };
 
@@ -32,8 +32,12 @@ $(document).ready( ()=> {
     beginAnnotation = (id) => {
         let ftr = dropdownMenuButton.text();
         if ( ftr === defaultDropDown) {
-            alert("Feature not selected from dropdown list.");
-        } else {
+            showModalClientError("Feature not selected from dropdown list.");
+        }
+        else if (!name) {
+            showModalClientError("Name is not specified")
+        }
+         else {
             window.location.href = `annotation?batchid=${id}&name=${name}&feature=${ftr}`;
         }
     };
@@ -83,7 +87,7 @@ $(document).ready( ()=> {
             }
         }
     })
-    .fail(err => { showModalError(err) });
+    .fail(err => { showModalServerError(err) });
 
     $(`#new-batch`).click(postToAnnotation);
     $(`#continue-batch`).click(postToAnnotation);

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -51,7 +51,7 @@ $(document).ready( ()=> {
     }
 
     function postToAdmin() {
-        $.post("insert_name", {name: name})
+        $.post("insert-name", {name: name})
             .done(() => {
                 window.location.href = `admin?name=${name}`;
             })

--- a/scripts/start_page.js
+++ b/scripts/start_page.js
@@ -18,7 +18,7 @@ $(document).ready(() => {
             console.log("Form Filled");
             name = $("#name").val();
             feature = $("#feature").val();
-            $.post("insert_name", {name: name})
+            $.post("insert-name", {name: name})
                 .done(() => {
                     window.location.href = `home?&name=${name}&feature=${feature}`;
                 })

--- a/server/batch_info.js
+++ b/server/batch_info.js
@@ -11,16 +11,17 @@ module.exports = function(db) {
                 if (batches) {
                     res.send(batches);
                 }
-                else { throw [500, "No batches in database"] }
+                else { throw [404, "No batches in database"] }
             })
             .catch(err => {
+                let response;
                 if (err.length === 2) {
-                   res.status(err[0]).send(err[1])
+                    response = {client: err[1]}
                 }
                 else {
-                    console.log(err);
-                    res.status(500).send("Unknown error occurred, check server logs")
+                    response = {client: "Unknown error occurred in retrieving batch info", server: err};
                 }
+                res.status(404).send(response)
             });
     };
 

--- a/server/export.js
+++ b/server/export.js
@@ -42,17 +42,19 @@ module.exports = function(db) {
                 select += " WHERE " + options.join(" AND ");
             }
             return db.none(`COPY (${select}) TO '/tmp/csv/export.csv' DELIMITER ',' CSV HEADER`, [req.query.name, req.query.date])
+                .catch(err => {
+                    throw ["Error writing csv on server", err]
+                })
         })
         .then(function() {
             // download file to client
             if (!fs.existsSync('/tmp/csv/export.csv')){
-                // fs.writeFile('/tmp/csv/export.csv', 'content')
-                res.status(500).send("Error: no export file created")
+                res.status(404).send({client: "Error: no export file created"})
             }
             else {
                 res.download(`/tmp/csv/export.csv`, 'export.csv', (err) => {
                     if (err) {
-                       res.status(500).send("Error downloading: Please try again\n")
+                       res.status(404).send({client: "Error downloading: Please try again\n", server: err})
                     }
                 });
             }
@@ -60,18 +62,19 @@ module.exports = function(db) {
         .catch(function(err) {
             // runs on reject() or throw, meant to catch errors
             console.log(err);
+            res.status(404).sent({client: "Unknown error occurred in exporting", server: err})
         });
     };
 
     module.send_users = function(req, res) {
-        db.any('select username from users', [true]).then((data) => {
+        db.any('SELECT username FROM users', [true]).then((data) => {
             users = [];
             data.forEach(item => {
                 users.push(item.username);
             });
             res.send(users);
         }).catch(err => {
-            res.sendStatus(500); // no users
+            res.status(404).send({client: "Unknown error occurred in finding user", server: err}); // no users
         });
     };
 

--- a/server/image_response.js
+++ b/server/image_response.js
@@ -18,14 +18,14 @@ module.exports = function(db, image_dir) {
                 // image found
                 let batchPath = path.join(image_dir, image.batches[0].toString());
                 let imagePath;
-                let imageFileName = image.hash + image.extension;
-                if (large) { imagePath = path.join(batchPath, imageFileName) }
-                // get downsampled image instead
-                else { imagePath = path.join(path.join(batchPath, 'ds/'), imageFileName)}
+                if (large) { imagePath = path.join(batchPath, image.hash + image.extension) }
+                // get downsampled image instead (will always be .png)
+                else { imagePath = path.join(path.join(batchPath, 'ds/'), image.hash + ".png")}
                 fs.access(imagePath, fs.constants.F_OK, (err) => {
                     if (err) {
-                        res.status(404).send({client: `Could not access image ${imageFileName} in file system`,
+                        res.status(404).send({client: `Could not access image ${image.hash} in file system`,
                                                 server: err});
+                        console.log(err)
                     }
                     else {
                         res.sendFile(imagePath);
@@ -35,6 +35,7 @@ module.exports = function(db, image_dir) {
             .catch((err) => {
                 // most likely image doesn't exist in DB
                 res.status(404).send({client: `Image of id "${id}" not found in database`, server: err});
+                console.log(err)
             });
     };
 

--- a/server/image_response.js
+++ b/server/image_response.js
@@ -10,9 +10,13 @@ module.exports = function(db, image_dir) {
     //      - get the id from the URL query
     //      - find the image that matches that id
     // Outputs: Image file of next image
-    module.get_img = function (req, res) {
+    module.getImage = function (req, res) {
         let id = req.query.id;
         let large = req.query.large;
+        if (!id) {
+            res.status(404).send({client: "No image ID given"});
+            return;
+        }
         db.one("SELECT * FROM images WHERE id=$1", id)
             .then((image) => {
                 // image found
@@ -40,10 +44,14 @@ module.exports = function(db, image_dir) {
     };
 
 
-    module.get_batch_status = function (req, res) {
+    module.getBatchStatus = function (req, res) {
         let batchID = req.query.batchid;
         let user = req.query.user;
         let feature = req.query.feature;
+        if (!batchID || !user || !feature) {
+            res.status(400).send({client: "Invalid query parameters for batch status"});
+            return;
+        }
         let payload = [];
 
         db.one("SELECT * FROM batches WHERE id = $1", batchID)


### PR DESCRIPTION
This branch adds 2 major features:
- `showModalClientError`: function to show modal warning on the client side, accepts a string as its parameter 
- `showModalServerError`: function to show modal error for error on server side, accepts a jqXHR error object

All `$.get` requests should have a fail condition that shows the server modal error, and any issues on the client side can be displayed with the client modal error. 